### PR TITLE
shared/bin/qbuild: add support for QNAP_SIGNING_SCRIPT environment va…

### DIFF
--- a/shared/bin/qbuild
+++ b/shared/bin/qbuild
@@ -955,7 +955,22 @@ add_qdk_area_end(){
 
 # Add signature to QPKG.
 add_qpkg_signature(){
-	if [ "x${QNAP_CODE_SIGNING}" = "x1" ]; then
+	if [ -n "${QNAP_SIGNING_SCRIPT}" ]; then
+		verbose_msg "Using custom signing script at ${QNAP_SIGNING_SCRIPT}"
+		openssl dgst -sha1 -binary "${QDK_QPKG_FILE}" > "${QDK_QPKG_FILE}.sha"
+		"${QNAP_SIGNING_SCRIPT}" "${QDK_QPKG_FILE}.sha" > "${QDK_QPKG_FILE}.msg" || exit 1
+		/bin/rm ${QDK_QPKG_FILE}.sha
+		if [ -f "${QDK_QPKG_FILE}.msg" ]; then
+			add_qdk_area_begin
+			add_qdk_area_code_signing "${QDK_QPKG_FILE}.msg"
+			add_qdk_area_end
+			SIG=`openssl cms -cmsout -in "${QDK_QPKG_FILE}.msg" 2>/dev/null | tr -d '\n' | tail -c 32`
+			echo "${SIG}" > "${QDK_BUILD_DIR}/${QDK_QPKG_FILE}.codesigning"
+			/bin/rm "${QDK_QPKG_FILE}.msg"
+		else
+			err_msg "$QDK_QPKG_FILE: Code signing digital signature was not added"
+		fi
+	elif [ "x${QNAP_CODE_SIGNING}" = "x1" ]; then
 		verbose_msg "Connecting to code signing server to create digital signature..."
 		[ -z "$QNAP_CODE_SIGNING_SERVER_IP" ] && QNAP_CODE_SIGNING_SERVER_IP=$DEFAULT_QNAP_CODE_SIGNING_SERVER_IP
 		[ -z "$QNAP_CODE_SIGNING_SERVER_PORT" ] && QNAP_CODE_SIGNING_SERVER_PORT=$DEFAULT_QNAP_CODE_SIGNING_SERVER_PORT


### PR DESCRIPTION
…riable

When specified, this script will be used to sign the qpkg instead of the built-in signing logic.

This is useful, for example, to integrate with cloud-based HSMs.

Updates tailscale/corp#23528